### PR TITLE
DateViewHelper causes an Issue with Flow 5.x

### DIFF
--- a/Classes/ViewHelpers/Internal/Form/DateViewHelper.php
+++ b/Classes/ViewHelpers/Internal/Form/DateViewHelper.php
@@ -22,25 +22,23 @@ class DateViewHelper extends TextfieldViewHelper
         // HINT: we use a format compatible with the input type Date
         $this->registerArgument('format', 'string', 'A Format string compatible with the DateTimeConverter.', FALSE, 'MULTIPLE');
     }
-
+    
     /**
      * Renders the textfield.
      *
-     * @param boolean $required If the field is required or not
-     * @param string $type
      * @return string
      * @api
      */
-    public function render($required = FALSE, $type = 'text')
+    public function render()
     {
+        $this->tag->addAttribute('type', 'date');
 
-        $content = parent::render($required, 'date');
+        $content = parent::render();
 
         $content .= '<input type="hidden" name="' . $this->prefixFieldName(parent::getNameWithoutPrefix()) . '[dateFormat]" value="' . htmlspecialchars($this->arguments['format']) . '" />';
 
         return $content;
     }
-
 
     protected function getNameWithoutPrefix()
     {

--- a/Classes/ViewHelpers/Internal/Form/DateViewHelper.php
+++ b/Classes/ViewHelpers/Internal/Form/DateViewHelper.php
@@ -45,6 +45,10 @@ class DateViewHelper extends TextfieldViewHelper
         return parent::getNameWithoutPrefix() . '[date]';
     }
 
+    /**
+     * @param bool $ignoreSubmittedFormData
+     * @return mixed|null
+     */
     protected function getValueAttribute($ignoreSubmittedFormData = FALSE)
     {
         $value = parent::getValueAttribute($ignoreSubmittedFormData);


### PR DESCRIPTION
Since the arguments for the render method where [removed](https://github.com/neos/fluidadaptor/commit/d312d8ff2dd2eb8ce2babb270446c2527d765436) in Flow 5.0 I had to adjust the view helper. Maybe its better to create a new tag that is only compatible with 5.x?