### PR TITLE
Fix FunctionalTests

### DIFF
--- a/Classes/Controller/BaseControllerTrait.php
+++ b/Classes/Controller/BaseControllerTrait.php
@@ -84,6 +84,8 @@ trait BaseControllerTrait
     }
 
     /**
+     * @Neos\Flow\Annotations\CompileStatic
+     *
      * @param ObjectManagerInterface $objectManager
      * @return array
      */

--- a/Classes/Controller/BaseControllerTrait.php
+++ b/Classes/Controller/BaseControllerTrait.php
@@ -84,8 +84,6 @@ trait BaseControllerTrait
     }
 
     /**
-     * @Flow\CompileStatic
-     *
      * @param ObjectManagerInterface $objectManager
      * @return array
      */


### PR DESCRIPTION
As described here #14 the `CompileStatic` annotation breaks functional tests for all packages installed.
