### PR TITLE
BUGFIX: missing packageKey in console output in generateCrudController

### DIFF
--- a/Classes/Command/CrudGeneratorService.php
+++ b/Classes/Command/CrudGeneratorService.php
@@ -33,7 +33,7 @@ class CrudGeneratorService
      * @param string $packageKey The package key of the controller's package
      * @param string $subpackage An optional subpackage name
      * @param string $controllerName The name of the new controller
-     * @param string $modelClassName The name of the model to base the controler on
+     * @param string $modelClassName The name of the model to base the controller on
      * @param boolean $overwrite Overwrite any existing files?
      * @return array An array of generated filenames
      * @throws UnknownPackageException
@@ -148,6 +148,6 @@ class CrudGeneratorService
     private function getNamespaceBaseDirectory($packageKey)
     {
         $package = $this->packageManager->getPackage($packageKey);
-        return Files::getNormalizedPath($package->getPackagePath() . '/Classes/');
+        return Files::getNormalizedPath($package->getPackagePath() . 'Classes/');
     }
 }


### PR DESCRIPTION
Resolves: #24 

## Before:

![SCR-20231110-pltq](https://github.com/sandstorm/CrudForms/assets/39345336/eb17cf8e-89fa-4e59-b3a8-81a8ce423a35)

## After:
![SCR-20231110-pokz](https://github.com/sandstorm/CrudForms/assets/39345336/aa2531a0-a7c4-4c36-8965-2eb2a56f5177)
