### PR TITLE
FEATURE: Add ability to make form fields required in CrudForms\FormField annotation

### DIFF
--- a/Classes/Annotations/FormField.php
+++ b/Classes/Annotations/FormField.php
@@ -20,6 +20,8 @@ final class FormField
     // only makes sense if editor == SingleSelect
     public $repository;
 
+    public $required = FALSE;
+
     // Only makes sense if editor == Radio
     public $options;
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ In your Model, annotate the field using the `@Crud\FormField` annotation, which 
 - `repository`: specify a repository to retrieve option values from (format: full\repository\class\name[::methodName])
 - `configuration`: a generic array of configuration options, available everywhere for customizations. By the base classes, the following configuration options are supported:
 - `formFieldWrapperClassName`: CSS class name to be applied to the wrapping element for each form field (to have field-specific classes)
+- `required`: specify, if the form field is required. Supported editors are DateTime, Radio, String and TextArea.
  
 
 ## hiding properties from listing and forms, sorting them, labeling them

--- a/Resources/Private/Partials/CrudForms/Bootstrap4/Form.html
+++ b/Resources/Private/Partials/CrudForms/Bootstrap4/Form.html
@@ -3,7 +3,7 @@
 <fieldset>
     <f:for each="{fields}" as="field">
         <div class="form-group {field.configuration.formFieldWrapperClassName} {f:validation.ifHasErrors(for: 'object.{field.property}', then: ' has-danger')}">
-            <label class="form-control-label">{field.label}</label>
+						<f:render partial="CrudForms/Helpers/RequiredFormFieldLabel" arguments="{field: field}"/>
             <f:if condition="{field.editor}">
                 <f:then>
                     <f:render partial="CrudForms/Helpers/Editor/{field.editor}" arguments="{formFieldClass: 'form-control', field: field, object: object, value: '{object -> crud:internal.objectAccess(property: field.property)}'}"/>

--- a/Resources/Private/Partials/CrudForms/Form.html
+++ b/Resources/Private/Partials/CrudForms/Form.html
@@ -3,7 +3,7 @@
 <fieldset>
     <f:for each="{fields}" as="field">
         <div class="form-field  {field.configuration.formFieldWrapperClassName} {f:validation.ifHasErrors(for: 'object.{field.property}', then: ' has-error')}">
-            <label>{field.label}
+						<f:render partial="CrudForms/Helpers/RequiredFormFieldLabel" arguments="{field: field}"/>
                 <f:if condition="{field.editor}">
                     <f:then>
                         <f:render partial="CrudForms/Helpers/Editor/{field.editor}" arguments="{field: field, object: object, value: '{object -> crud:internal.objectAccess(property: field.property)}'}"/>
@@ -12,7 +12,6 @@
                         <f:render partial="CrudForms/Helpers/Editor/String" arguments="{field: field, object: object, value: '{object -> crud:internal.objectAccess(property: field.property)}'}"/>
                     </f:else>
                 </f:if>
-            </label>
             <f:render partial="CrudForms/Helpers/FormFieldValidationResults" arguments="{fieldname: 'object.{field.property}'}"/>
         </div>
     </f:for>

--- a/Resources/Private/Partials/CrudForms/Helpers/Editor/DateTime.html
+++ b/Resources/Private/Partials/CrudForms/Helpers/Editor/DateTime.html
@@ -5,6 +5,6 @@
         {value -> f:format.date()}
     </f:then>
     <f:else>
-        <crud:internal.form.date property="{field.property}" id="{field.property}" format="Y-m-d" class="{formFieldClass}"/>
+        <crud:internal.form.date required="{f:if(condition:field.required, then: 'required', else: '')}" property="{field.property}" id="{field.property}" format="Y-m-d" class="{formFieldClass}"/>
     </f:else>
 </f:if>

--- a/Resources/Private/Partials/CrudForms/Helpers/Editor/Radio.html
+++ b/Resources/Private/Partials/CrudForms/Helpers/Editor/Radio.html
@@ -2,6 +2,6 @@
 
 <f:for each="{field.options}" as="option">
     <br />
-        <f:form.radio property="{field.property}" value="{option.value}" class="{formFieldClass}" />
+        <f:form.radio property="{field.property}" value="{option.value}" class="{formFieldClass}" additionalAttributes="{f:if(condition:field.required, then: '{required: \'required\'}', else: '')}"/>
         {option.label}
 </f:for>

--- a/Resources/Private/Partials/CrudForms/Helpers/Editor/String.html
+++ b/Resources/Private/Partials/CrudForms/Helpers/Editor/String.html
@@ -1,1 +1,1 @@
-<f:form.textfield property="{field.property}" id="{field.property}" readonly="{f:if(condition:field.readonly, then: 'readonly', else: '')}" class="{formFieldClass}"/>
+<f:form.textfield property="{field.property}" id="{field.property}" required="{f:if(condition:field.required, then: 'required', else: '')}" readonly="{f:if(condition:field.readonly, then: 'readonly', else: '')}" class="{formFieldClass}"/>

--- a/Resources/Private/Partials/CrudForms/Helpers/Editor/TextArea.html
+++ b/Resources/Private/Partials/CrudForms/Helpers/Editor/TextArea.html
@@ -1,1 +1,1 @@
-<f:form.textarea property="{field.property}" id="{field.property}" class="{formFieldClass}" />
+<f:form.textarea property="{field.property}" required="{f:if(condition:field.required, then: 'required', else: '')}" id="{field.property}" class="{formFieldClass}" />

--- a/Resources/Private/Partials/CrudForms/Helpers/RequiredFormFieldLabel.html
+++ b/Resources/Private/Partials/CrudForms/Helpers/RequiredFormFieldLabel.html
@@ -1,0 +1,8 @@
+<f:if condition="{field.required}">
+	<f:then>
+		<label class="neos-control-label">{field.label} *</label>
+	</f:then>
+	<f:else>
+		<label class="neos-control-label">{field.label}</label>
+	</f:else>
+</f:if>

--- a/Resources/Private/Partials/CrudForms/Neos/Form.html
+++ b/Resources/Private/Partials/CrudForms/Neos/Form.html
@@ -2,7 +2,7 @@
 <fieldset class="neos-span5">
     <f:for each="{fields}" as="field">
         <div class="neos-control-group {field.configuration.formFieldWrapperClassName} {f:validation.ifHasErrors(for: 'object.{field.property}', then: ' neos-error')}">
-            <label class="neos-control-label">{field.label}</label>
+						<f:render partial="CrudForms/Helpers/RequiredFormFieldLabel" arguments="{field: field}"/>
             <div class="neos-controls">
                 <f:if condition="{field.editor}">
                     <f:then>


### PR DESCRIPTION
resolves: #23

## Description

This pull request adds the ability to additionally add the `required` value in the `@Crud\FormField` annotation. The form fields with the editors `DateTime`, `Radio`, `String` and `TextArea` are then marked as mandatory fields. A marking is visible to the editor through the `*`. Of course, this only appears if the `required` option is set in the `@Crud\FormField` annotation. By default, `required` is set to `false`.

The `SingleSelect` editor has not changed, as it has the first value configured as the default value. It is therefore not possible to leave this empty.